### PR TITLE
fix(vendetta): channel icon color + default accent

### DIFF
--- a/frappe.json
+++ b/frappe.json
@@ -8,7 +8,7 @@
     ],
     "semanticColors": {
       "BACKGROUND_ACCENT": [
-      "#8caaee"
+      "#ca9ee6"
       ],
       "BACKGROUND_MENTIONED": [
       "rgba(229, 200, 144, 0.1)"
@@ -62,7 +62,7 @@
       "#232634"
       ],
       "CHANNEL_ICON": [
-      "#949ec5"
+      "#a5adce"
       ],
       "CHANNELS_DEFAULT": [
       "#949ec5"

--- a/latte.json
+++ b/latte.json
@@ -11,7 +11,7 @@
       "#9ca0b0", "#9ca0b0"
       ],
       "BACKGROUND_ACCENT": [
-      "#7c7f93", "#7c7f93"
+      "#8839ef", "#8839ef"
       ],
       "BACKGROUND_MESSAGE_HOVER": [
       "#9ca0b0", "#9ca0b0"

--- a/macchiato.json
+++ b/macchiato.json
@@ -50,7 +50,7 @@
       "#181926"
       ],
       "CHANNEL_ICON": [
-      "#c6a0f6"
+      "#a5adcb"
       ],
       "CHANNELS_DEFAULT": [
       "#72778F"

--- a/mocha.json
+++ b/mocha.json
@@ -8,7 +8,7 @@
     ],
     "semanticColors": {
       "BACKGROUND_ACCENT": [
-      "#f38ba8"
+      "#cba6f7"
       ],
       "BACKGROUND_MENTIONED": [
       "#313244"
@@ -56,7 +56,7 @@
       "#11111b"
       ],
       "CHANNEL_ICON": [
-      "#cba6f7"
+      "#a6adc8"
       ],
       "CHANNELS_DEFAULT": [
       "#9399b2"


### PR DESCRIPTION
according to hammy, default accent is now mauve; channel icon color is now subtext0 to better match desktop discord theme